### PR TITLE
fix(client/src/redux/authActions): login action

### DIFF
--- a/client/src/components/Authentication/Authentication.jsx
+++ b/client/src/components/Authentication/Authentication.jsx
@@ -15,7 +15,9 @@ export default function ExternAuthentication(props) {
   const dispatch = useDispatch();
 
   const responseGoogle = (response) => {
-    dispatch(login({ google: response.tokenId }));
+    if (response.tokenId){
+      dispatch(login({ google: response.tokenId }));
+    }
   };
 
   const responseFacebook = (response) => {

--- a/client/src/redux/actions/types/authActions.js
+++ b/client/src/redux/actions/types/authActions.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import * as actionTypes from '../names';
 import * as endpoints from '../../../utils/endpoints';
 
-export function login(payload) {
+export function login(payload, tokenLogin = false) {
   return async function (dispatch) {
     try {
       const response = await axios.post(`${endpoints.AUTH_LOGIN}`, payload);
@@ -11,10 +11,11 @@ export function login(payload) {
         payload: setUserSession(response.data)
       });
     } catch (e) {
-      return dispatch({
-        type: actionTypes.LOGIN_FAILED,
-        payload: e.response.data
-      });
+      if (!tokenLogin)
+        return dispatch({
+          type: actionTypes.LOGIN_FAILED,
+          payload: e.response.data
+        });
     }
   }
 }

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -46,7 +46,7 @@ const store = createStore(
 );
 
 if (session.token) {
-  store.dispatch(login({ token: session.token }));
+  store.dispatch(login({ token: session.token }, true));
 }
 
 export default store;


### PR DESCRIPTION
- Ya no se guarda el error si el token del storage está expirado.
- Se verifica que el login de google sea exitoso para hacer el login.